### PR TITLE
Add auto dependency checking to build

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,8 +15,14 @@ LINK_FLAGS := -Wl,-rpath,/opt/GenICam_v3_0_NI/bin/Linux32_ARM
 INCLUDE_FLAGS := $(foreach dir,$(INCLUDE_DIRS),-I"$(dir)")
 LIB_FLAGS := $(foreach dir,$(LIB_DIRS),-L"$(dir)")
 
+.PHONY: all
 # all target
-all: frc-build
+all: $(BUILD_DIR)/FRCUserProgram
+
+-include $(OBJS:.o=.d)
+
+deploy: $(BUILD_DIR)/FRCUserProgram
+	ant
 
 # linting
 lint:
@@ -30,7 +36,7 @@ $(OUTPUT_DIRS):
 	$(MKDIR) $@
 
 # frc-build to build full project
-frc-build: output-dir $(OBJS)
+$(BUILD_DIR)/FRCUserProgram: output-dir $(OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: Cross G++ Linker'
 	$(CPP) $(LINK_FLAGS) $(LIB_FLAGS) -o "$(BUILD_DIR)/FRCUserProgram" $(OBJS) -lwpi
@@ -49,3 +55,7 @@ $(BUILD_DIR)/%.o: %.cpp
 clean:
 	-$(RM) $(BUILD_DIR)
 	-@echo ' '
+
+# Dep files
+$(BUILD_DIR)/%.d: $(OUTPUT_DIRS)
+	@$(CPP) -MM -MT $(@:.d=.o) $(CFLAGS) $(INCLUDE_FLAGS) $(@:build/%.d=%.cpp) > $@;


### PR DESCRIPTION
Fixes #2 

This should avoid builds where half the files were compiled using an
old header and half were with the new headers. Hopefully fixing bugs
along the way :-)

Also add 'deploy' target to run ant after building is complete